### PR TITLE
Press ESC to clear keyboard focus first

### DIFF
--- a/src/main/java/com/ldtteam/blockui/views/BOWindow.java
+++ b/src/main/java/com/ldtteam/blockui/views/BOWindow.java
@@ -228,7 +228,14 @@ public class BOWindow extends View
     {
         if (key == GLFW.GLFW_KEY_ESCAPE)
         {
-            close();
+            if (getFocus() != null)
+            {
+                clearFocus();
+            }
+            else
+            {
+                close();
+            }
             return true;
         }
         return false;


### PR DESCRIPTION
Since I'm here anyway, this upstreams the following Structurize code, needed to support plain-input-key keybinds coexisting with input fields:

https://github.com/ldtteam/Structurize/blob/af1d0d34be00f0bf044c9bd5acb15bb7c5781f94/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java#L273-L277

The two will happily coexist but the above can be removed after this is merged.  It seems useful to have this functionality generally available.