### PR TITLE
Scrollinglist dynamic size

### DIFF
--- a/src/main/java/com/ldtteam/blockui/mod/ClientEventSubscriber.java
+++ b/src/main/java/com/ldtteam/blockui/mod/ClientEventSubscriber.java
@@ -1,14 +1,20 @@
 package com.ldtteam.blockui.mod;
 
 import com.ldtteam.blockui.BOScreen;
+import com.ldtteam.blockui.Pane;
+import com.ldtteam.blockui.controls.Text;
 import com.ldtteam.blockui.hooks.HookManager;
 import com.ldtteam.blockui.hooks.HookRegistries;
 import com.ldtteam.blockui.mod.container.ContainerHook;
+import com.ldtteam.blockui.util.records.SizeI;
 import com.ldtteam.blockui.views.BOWindow;
+import com.ldtteam.blockui.views.ScrollingList;
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Tuple;
 import net.minecraftforge.client.event.InputEvent.MouseScrollingEvent;
 import net.minecraftforge.client.event.RenderGuiOverlayEvent;
 import net.minecraftforge.client.gui.overlay.VanillaGuiOverlay;
@@ -18,6 +24,7 @@ import net.minecraftforge.event.TickEvent.ClientTickEvent;
 import net.minecraftforge.event.TickEvent.Phase;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 
 public class ClientEventSubscriber
@@ -57,6 +64,47 @@ public class ClientEventSubscriber
             else if (InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), GLFW.GLFW_KEY_C))
             {
                 new BOWindow(new ResourceLocation(BlockUI.MOD_ID, "gui/test2.xml")).open();
+            }
+            else if (InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), GLFW.GLFW_KEY_Z))
+            {
+                final BOWindow boWindow3 = new BOWindow(new ResourceLocation(BlockUI.MOD_ID, "gui/test3.xml"));
+                boWindow3.open();
+
+                final ScrollingList list1 = boWindow3.findPaneOfTypeByID("list1", ScrollingList.class);
+                list1.setDataProvider(new ScrollingList.DataProvider() {
+                    @Override
+                    public int getElementCount()
+                    {
+                        return 10;
+                    }
+
+                    @Override
+                    public void updateElement(final int index, final Pane rowPane)
+                    {
+                        rowPane.findPaneByType(Text.class).setText(Component.literal("Hi " + index));
+                    }
+                });
+
+                final ScrollingList list2 = boWindow3.findPaneOfTypeByID("list2", ScrollingList.class);
+                list2.setDataProvider(new ScrollingList.DataProvider() {
+                    @Override
+                    public int getElementCount()
+                    {
+                        return 10;
+                    }
+
+                    @Override
+                    public SizeI.@Nullable MutableSizeI getElementSize(final int index, final Pane rowPane)
+                    {
+                        return index % 2 == 0 ? new SizeI.MutableSizeI(100, 40) : null;
+                    }
+
+                    @Override
+                    public void updateElement(final int index, final Pane rowPane)
+                    {
+                        rowPane.findPaneByType(Text.class).setText(Component.literal("Hi " + index));
+                    }
+                });
             }
         }
 

--- a/src/main/java/com/ldtteam/blockui/mod/ClientEventSubscriber.java
+++ b/src/main/java/com/ldtteam/blockui/mod/ClientEventSubscriber.java
@@ -14,7 +14,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.Tuple;
 import net.minecraftforge.client.event.InputEvent.MouseScrollingEvent;
 import net.minecraftforge.client.event.RenderGuiOverlayEvent;
 import net.minecraftforge.client.gui.overlay.VanillaGuiOverlay;
@@ -94,9 +93,9 @@ public class ClientEventSubscriber
                     }
 
                     @Override
-                    public SizeI.@Nullable MutableSizeI getElementSize(final int index, final Pane rowPane)
+                    public @Nullable SizeI getElementSize(final int index, final Pane rowPane)
                     {
-                        return index % 2 == 0 ? new SizeI.MutableSizeI(100, 40) : null;
+                        return index % 2 == 0 ? new SizeI(100, 40) : null;
                     }
 
                     @Override

--- a/src/main/java/com/ldtteam/blockui/mod/ClientEventSubscriber.java
+++ b/src/main/java/com/ldtteam/blockui/mod/ClientEventSubscriber.java
@@ -66,6 +66,7 @@ public class ClientEventSubscriber
                 window.addChild(createTestGuiButton(0, "General All-in-one", new ResourceLocation(BlockUI.MOD_ID, "gui/test.xml")));
                 window.addChild(createTestGuiButton(1, "Tooltip Positioning", new ResourceLocation(BlockUI.MOD_ID, "gui/test2.xml")));
                 window.addChild(createTestGuiButton(2, "ItemIcon To BlockState", new ResourceLocation(BlockUI.MOD_ID, "gui/test3.xml"), BlockStateTestGui::setup));
+                window.addChild(createTestGuiButton(3, "Dynamic ScrollingLists", new ResourceLocation(BlockUI.MOD_ID, "gui/test4.xml"), DynamicScrollingListGui::setup));
                 window.open();
             }
         }

--- a/src/main/java/com/ldtteam/blockui/mod/DynamicScrollingListGui.java
+++ b/src/main/java/com/ldtteam/blockui/mod/DynamicScrollingListGui.java
@@ -1,0 +1,56 @@
+package com.ldtteam.blockui.mod;
+
+import com.ldtteam.blockui.Pane;
+import com.ldtteam.blockui.controls.Text;
+import com.ldtteam.blockui.util.records.SizeI;
+import com.ldtteam.blockui.views.BOWindow;
+import com.ldtteam.blockui.views.ScrollingList;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Sets up gui for dynamic scrolling lists.
+ */
+public class DynamicScrollingListGui
+{
+    public static void setup(final BOWindow window)
+    {
+        final ScrollingList list1 = window.findPaneOfTypeByID("list1", ScrollingList.class);
+        list1.setDataProvider(new ScrollingList.DataProvider()
+        {
+            @Override
+            public int getElementCount()
+            {
+                return 10;
+            }
+
+            @Override
+            public void updateElement(final int index, final Pane rowPane)
+            {
+                rowPane.findPaneByType(Text.class).setText(Component.literal("Hi " + index));
+            }
+        });
+
+        final ScrollingList list2 = window.findPaneOfTypeByID("list2", ScrollingList.class);
+        list2.setDataProvider(new ScrollingList.DataProvider()
+        {
+            @Override
+            public int getElementCount()
+            {
+                return 10;
+            }
+
+            @Override
+            public @Nullable SizeI getElementSize(final int index, final Pane rowPane)
+            {
+                return index % 2 == 0 ? new SizeI(100, 40) : null;
+            }
+
+            @Override
+            public void updateElement(final int index, final Pane rowPane)
+            {
+                rowPane.findPaneByType(Text.class).setText(Component.literal("Hi " + index));
+            }
+        });
+    }
+}

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingList.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingList.java
@@ -3,7 +3,6 @@ package com.ldtteam.blockui.views;
 import com.ldtteam.blockui.Pane;
 import com.ldtteam.blockui.PaneParams;
 import com.ldtteam.blockui.util.records.SizeI;
-import net.minecraft.util.Tuple;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -142,8 +141,7 @@ public class ScrollingList extends ScrollingView
          * @param rowPane the parent Pane for the row, containing the elements to update
          * @return a new size for the element, or null to use the template element size.
          */
-        @Nullable
-        default SizeI.MutableSizeI getElementSize(int index, Pane rowPane)
+        default @Nullable SizeI getElementSize(int index, Pane rowPane)
         {
             return null;
         }

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingList.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingList.java
@@ -2,6 +2,9 @@ package com.ldtteam.blockui.views;
 
 import com.ldtteam.blockui.Pane;
 import com.ldtteam.blockui.PaneParams;
+import com.ldtteam.blockui.util.records.SizeI;
+import net.minecraft.util.Tuple;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.function.IntSupplier;
@@ -14,11 +17,11 @@ import java.util.function.IntSupplier;
  */
 public class ScrollingList extends ScrollingView
 {
-    protected int childSpacing = 0;
+    protected int          childSpacing = 0;
     // Runtime
     protected DataProvider dataProvider;
-    private PaneParams listNodeParams;
-    private int maxHeight;
+    private   PaneParams   listNodeParams;
+    private   int          maxHeight;
 
     /**
      * Default constructor required by Blockout.
@@ -42,6 +45,7 @@ public class ScrollingList extends ScrollingView
 
     /**
      * Max height setter.
+     *
      * @param maxHeight the height to set.
      */
     public void setMaxHeight(final int maxHeight)
@@ -130,6 +134,19 @@ public class ScrollingList extends ScrollingView
          * @return number of rows in the list
          */
         int getElementCount();
+
+        /**
+         * Override this to pick a custom size for this element. Tuple arguments are width and height, in that order.
+         *
+         * @param index   the index of the row/list element
+         * @param rowPane the parent Pane for the row, containing the elements to update
+         * @return a new size for the element, or null to use the template element size.
+         */
+        @Nullable
+        default SizeI.MutableSizeI getElementSize(int index, Pane rowPane)
+        {
+            return null;
+        }
 
         /**
          * Override this to update the Panes for a given row.

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
@@ -47,10 +47,10 @@ public class ScrollingListContainer extends ScrollingContainer
 
                 child.setPosition(0, currentYpos);
 
-                final @Nullable SizeI.MutableSizeI customElementSize = dataProvider.getElementSize(i, child);
+                final @Nullable SizeI customElementSize = dataProvider.getElementSize(i, child);
                 if (customElementSize != null)
                 {
-                    child.setSize(customElementSize.width, customElementSize.height);
+                    child.setSize(customElementSize.width(), customElementSize.height());
                 }
 
                 if (currentYpos + child.getHeight() >= scrollY && currentYpos <= scrollY + height)

--- a/src/main/resources/assets/blockui/gui/test3.xml
+++ b/src/main/resources/assets/blockui/gui/test3.xml
@@ -1,0 +1,8 @@
+<window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="block_ui.xsd" size="320 240">
+    <list id="list1" size="160 240">
+        <label size="100 20" align="TOP_LEFT"/>
+    </list>
+    <list id="list2" size="160 240" pos="160 0">
+        <label size="100 20" align="TOP_LEFT"/>
+    </list>
+</window>

--- a/src/main/resources/assets/blockui/gui/test4.xml
+++ b/src/main/resources/assets/blockui/gui/test4.xml
@@ -1,0 +1,8 @@
+<window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="block_ui.xsd" size="1600 900" type="FIXED_VANILLA" pause="true" lightbox="true">
+    <list id="list1" size="160 240">
+        <label size="100 20" align="TOP_LEFT"/>
+    </list>
+    <list id="list2" size="160 240" pos="160 0">
+        <label size="100 20" align="TOP_LEFT"/>
+    </list>
+</window>

--- a/src/main/resources/assets/blockui/gui/test4.xml
+++ b/src/main/resources/assets/blockui/gui/test4.xml
@@ -1,4 +1,4 @@
-<window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="block_ui.xsd" size="1600 900" type="FIXED_VANILLA" pause="true" lightbox="true">
+<window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="block_ui.xsd" size="320 240" type="FIXED_VANILLA" pause="true" lightbox="true">
     <list id="list1" size="160 240">
         <label size="100 20" align="TOP_LEFT"/>
     </list>


### PR DESCRIPTION
Allow for scrolling list items to have a dynamic size, by using a new method in the dataprovider to calculate a dynamic size for the element.