### PR TITLE
Make network abstract better

### DIFF
--- a/src/main/java/com/ldtteam/common/network/AbstractClientPlayMessage.java
+++ b/src/main/java/com/ldtteam/common/network/AbstractClientPlayMessage.java
@@ -10,6 +10,8 @@ import net.neoforged.neoforge.network.handling.PlayPayloadContext;
 public abstract class AbstractClientPlayMessage extends AbstractUnsidedPlayMessage implements IClientboundDistributor
 {
     /**
+     * This constructor should be called from message call site, ie. the code where you instantiate the message to send it to client
+     *
      * @param type message type
      */
     public AbstractClientPlayMessage(final PlayMessageType<?> type)
@@ -22,8 +24,9 @@ public abstract class AbstractClientPlayMessage extends AbstractUnsidedPlayMessa
      *
      * @param buf received network payload
      * @param type message type
+     * @apiNote you can keep this protected to reduce visibility
      */
-    public AbstractClientPlayMessage(final FriendlyByteBuf buf, final PlayMessageType<?> type)
+    protected AbstractClientPlayMessage(final FriendlyByteBuf buf, final PlayMessageType<?> type)
     {
         super(type);
     }

--- a/src/main/java/com/ldtteam/common/network/AbstractPlayMessage.java
+++ b/src/main/java/com/ldtteam/common/network/AbstractPlayMessage.java
@@ -13,6 +13,8 @@ public abstract class AbstractPlayMessage extends AbstractUnsidedPlayMessage imp
     IServerboundDistributor
 {
     /**
+     * This constructor should be called from message call site, ie. the code where you instantiate the message to send it to the other side
+     *
      * @param type message type
      */
     public AbstractPlayMessage(final PlayMessageType<?> type)
@@ -25,8 +27,9 @@ public abstract class AbstractPlayMessage extends AbstractUnsidedPlayMessage imp
      *
      * @param buf received network payload
      * @param type message type
+     * @apiNote you can keep this protected to reduce visibility
      */
-    public AbstractPlayMessage(final FriendlyByteBuf buf, final PlayMessageType<?> type)
+    protected AbstractPlayMessage(final FriendlyByteBuf buf, final PlayMessageType<?> type)
     {
         super(type);
     }

--- a/src/main/java/com/ldtteam/common/network/AbstractServerPlayMessage.java
+++ b/src/main/java/com/ldtteam/common/network/AbstractServerPlayMessage.java
@@ -10,6 +10,8 @@ import net.neoforged.neoforge.network.handling.PlayPayloadContext;
 public abstract class AbstractServerPlayMessage extends AbstractUnsidedPlayMessage implements IServerboundDistributor
 {
     /**
+     * This constructor should be called from message call site, ie. the code where you instantiate the message to send it to server
+     *
      * @param type message type
      */
     public AbstractServerPlayMessage(final PlayMessageType<?> type)
@@ -22,8 +24,9 @@ public abstract class AbstractServerPlayMessage extends AbstractUnsidedPlayMessa
      *
      * @param buf received network payload
      * @param type message type
+     * @apiNote you can keep this protected to reduce visibility
      */
-    public AbstractServerPlayMessage(final FriendlyByteBuf buf, final PlayMessageType<?> type)
+    protected AbstractServerPlayMessage(final FriendlyByteBuf buf, final PlayMessageType<?> type)
     {
         super(type);
     }

--- a/src/main/java/com/ldtteam/common/network/IClientboundDistributor.java
+++ b/src/main/java/com/ldtteam/common/network/IClientboundDistributor.java
@@ -36,7 +36,7 @@ public interface IClientboundDistributor extends CustomPacketPayload
         PacketDistributor.DIMENSION.with(dimensionKey).send(this);
     }
 
-    public default void sendToSpherePoint(final TargetPoint point)
+    public default void sendToTargetPoint(final TargetPoint point)
     {
         PacketDistributor.NEAR.with(point).send(this);
     }


### PR DESCRIPTION
Use protected instead of public visibility modifier
Add types allowing null player - in case we need them later
Change PlayMessageType deserialization type so we have less message ctors (when message extends abstract message)

_(already applied in mcol port, just sanity review check please :D )_