### PR TITLE
Scrolling list empty text

### DIFF
--- a/src/main/java/com/ldtteam/blockui/mod/ScrollingListsGui.java
+++ b/src/main/java/com/ldtteam/blockui/mod/ScrollingListsGui.java
@@ -125,7 +125,7 @@ public class ScrollingListsGui
             }
         });
 
-        window.findPaneOfTypeByID("list4add", Button.class).setHandler(button -> renderAmount.getAndIncrement());
-        window.findPaneOfTypeByID("list4remove", Button.class).setHandler(button -> renderAmount.getAndDecrement());
+        window.findPaneOfTypeByID("list4add", Button.class).setHandler(button -> renderAmount.getAndAdd(2));
+        window.findPaneOfTypeByID("list4remove", Button.class).setHandler(button -> renderAmount.getAndAdd(-2));
     }
 }

--- a/src/main/java/com/ldtteam/blockui/mod/ScrollingListsGui.java
+++ b/src/main/java/com/ldtteam/blockui/mod/ScrollingListsGui.java
@@ -1,6 +1,7 @@
 package com.ldtteam.blockui.mod;
 
 import com.ldtteam.blockui.Pane;
+import com.ldtteam.blockui.controls.Button;
 import com.ldtteam.blockui.controls.CheckBox;
 import com.ldtteam.blockui.controls.Text;
 import com.ldtteam.blockui.support.DataProviders.CheckListDataProvider;
@@ -12,6 +13,7 @@ import net.minecraft.network.chat.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Sets up gui for dynamic scrolling lists.
@@ -104,5 +106,26 @@ public class ScrollingListsGui
                 return booleans.size();
             }
         });
+
+        // Case 4: Empty list with empty texts
+        final AtomicInteger renderAmount = new AtomicInteger();
+        final ScrollingList list4 = window.findPaneOfTypeByID("list4", ScrollingList.class);
+        list4.setDataProvider(new DataProvider()
+        {
+            @Override
+            public int getElementCount()
+            {
+                return renderAmount.get();
+            }
+
+            @Override
+            public void updateElement(final int index, final Pane rowPane)
+            {
+                rowPane.findPaneByType(Text.class).setText(Component.literal("Hi " + index));
+            }
+        });
+
+        window.findPaneOfTypeByID("list4add", Button.class).setHandler(button -> renderAmount.getAndIncrement());
+        window.findPaneOfTypeByID("list4remove", Button.class).setHandler(button -> renderAmount.getAndDecrement());
     }
 }

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingList.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingList.java
@@ -45,8 +45,8 @@ public class ScrollingList extends ScrollingView
         childSpacing = params.getInteger("childspacing", childSpacing);
         this.setMaxHeight(height);
 
-        setEmptyText(params.getMultilineText("emptytext"));
         setEmptyTextColor(params.getColor("emptycolor", DEFAULT_TEXT_COLOR));
+        setEmptyText(params.getMultilineText("emptytext"));
         setEmptyTextScale(params.getDouble("emptyscale", DEFAULT_TEXT_SCALE));
     }
 

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingList.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingList.java
@@ -46,8 +46,8 @@ public class ScrollingList extends ScrollingView
         this.setMaxHeight(height);
 
         setEmptyTextColor(params.getColor("emptycolor", DEFAULT_TEXT_COLOR));
-        setEmptyText(params.getMultilineText("emptytext"));
         setEmptyTextScale(params.getDouble("emptyscale", DEFAULT_TEXT_SCALE));
+        setEmptyText(params.getMultilineText("emptytext"));
     }
 
     /**

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingList.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingList.java
@@ -3,9 +3,13 @@ package com.ldtteam.blockui.views;
 import com.ldtteam.blockui.Pane;
 import com.ldtteam.blockui.PaneParams;
 import com.ldtteam.blockui.views.ScrollingListContainer.RowSizeModifier;
+import net.minecraft.network.chat.MutableComponent;
 
 import java.util.List;
 import java.util.function.IntSupplier;
+
+import static com.ldtteam.blockui.controls.AbstractTextElement.DEFAULT_TEXT_COLOR;
+import static com.ldtteam.blockui.controls.AbstractTextElement.DEFAULT_TEXT_SCALE;
 
 /**
  * A ScrollingList is a View which can contain 0 or more children of a specific Pane or View type
@@ -15,10 +19,12 @@ import java.util.function.IntSupplier;
  */
 public class ScrollingList extends ScrollingView
 {
-    protected int          childSpacing = 0;
+    protected int childSpacing = 0;
+
     // Runtime
     protected DataProvider dataProvider;
-    private   int          maxHeight;
+
+    private int maxHeight;
 
     /**
      * Default constructor required by Blockout.
@@ -38,6 +44,50 @@ public class ScrollingList extends ScrollingView
         super(params);
         childSpacing = params.getInteger("childspacing", childSpacing);
         this.setMaxHeight(height);
+
+        setEmptyText(params.getMultilineText("emptytext"));
+        setEmptyTextColor(params.getColor("emptycolor", DEFAULT_TEXT_COLOR));
+        setEmptyTextScale(params.getDouble("emptyscale", DEFAULT_TEXT_SCALE));
+    }
+
+    /**
+     * Set the text shown when there are no items in the data provider.
+     *
+     * @param emptyText the component.
+     */
+    public void setEmptyText(final MutableComponent emptyText)
+    {
+        setEmptyText(List.of(emptyText));
+    }
+
+    /**
+     * Set the text shown when there are no items in the data provider.
+     *
+     * @param emptyText the list of components.
+     */
+    public void setEmptyText(final List<MutableComponent> emptyText)
+    {
+        ((ScrollingListContainer) container).setEmptyText(emptyText);
+    }
+
+    /**
+     * Set the text color for the empty text.
+     *
+     * @param emptyTextColor the color.
+     */
+    public void setEmptyTextColor(final int emptyTextColor)
+    {
+        ((ScrollingListContainer) container).setEmptyTextColor(emptyTextColor);
+    }
+
+    /**
+     * Set the text scale for the empty text.
+     *
+     * @param emptyTextScale the text scale.
+     */
+    public void setEmptyTextScale(final double emptyTextScale)
+    {
+        ((ScrollingListContainer) container).setEmptyTextScale(emptyTextScale);
     }
 
     /**

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
@@ -14,28 +14,16 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-import static com.ldtteam.blockui.controls.AbstractTextElement.DEFAULT_TEXT_COLOR;
-import static com.ldtteam.blockui.controls.AbstractTextElement.DEFAULT_TEXT_SCALE;
-
 /**
  * A Blockout pane that contains a scrolling line of other panes.
  */
 public class ScrollingListContainer extends ScrollingContainer
 {
     /**
-     * The current empty text values.
+     * The reference to the empty text label, if it exists.
      */
-    private List<MutableComponent> emptyText;
-
-    /**
-     * The current empty text color for the {@link ScrollingListContainer#emptyText}.
-     */
-    private int emptyTextColor = DEFAULT_TEXT_COLOR;
-
-    /**
-     * The current empty text scale for the {@link ScrollingListContainer#emptyText}.
-     */
-    private double emptyTextScale = DEFAULT_TEXT_SCALE;
+    @NotNull
+    private final Text emptyTextComponent;
 
     /**
      * The xml parameters for the row panes.
@@ -48,14 +36,13 @@ public class ScrollingListContainer extends ScrollingContainer
      */
     private SizeI templateSize = new SizeI(0, 0);
 
-    /**
-     * The reference to the empty text label, if it exists.
-     */
-    private Text currentEmptyTextComponent;
-
     ScrollingListContainer(final ScrollingList owner)
     {
         super(owner);
+
+        emptyTextComponent = new Text();
+        emptyTextComponent.setSize(this.width, this.height);
+        emptyTextComponent.setTextAlignment(Alignment.MIDDLE);
     }
 
     /**
@@ -65,39 +52,27 @@ public class ScrollingListContainer extends ScrollingContainer
      */
     public void setEmptyText(final List<MutableComponent> emptyText)
     {
-        this.emptyText = emptyText;
-        if (currentEmptyTextComponent != null)
-        {
-            currentEmptyTextComponent.setText(emptyText);
-        }
+        emptyTextComponent.setText(emptyText);
     }
 
     /**
-     * Set the text color for the {@link ScrollingListContainer#emptyText}.
+     * Set the text color for the empty text.
      *
      * @param emptyTextColor the color.
      */
     public void setEmptyTextColor(final int emptyTextColor)
     {
-        this.emptyTextColor = emptyTextColor;
-        if (currentEmptyTextComponent != null)
-        {
-            currentEmptyTextComponent.setColors(emptyTextColor);
-        }
+        emptyTextComponent.setColors(emptyTextColor);
     }
 
     /**
-     * Set the text scale for the {@link ScrollingListContainer#emptyText}.
+     * Set the text scale for the empty text.
      *
      * @param emptyTextScale the text scale.
      */
     public void setEmptyTextScale(final double emptyTextScale)
     {
-        this.emptyTextScale = emptyTextScale;
-        if (currentEmptyTextComponent != null)
-        {
-            currentEmptyTextComponent.setTextScale(emptyTextScale);
-        }
+        emptyTextComponent.setTextScale(emptyTextScale);
     }
 
     /**
@@ -132,14 +107,12 @@ public class ScrollingListContainer extends ScrollingContainer
             return;
         }
 
+        emptyTextComponent.setSize(this.width, this.height);
+
         final int numElements = (dataProvider != null) ? dataProvider.getElementCount() : 0;
         if (numElements > 0)
         {
-            if (currentEmptyTextComponent != null)
-            {
-                removeChild(currentEmptyTextComponent);
-                currentEmptyTextComponent = null;
-            }
+            removeChild(emptyTextComponent);
 
             final RowSizeModifier modifier = new RowSizeModifier();
 
@@ -176,22 +149,19 @@ public class ScrollingListContainer extends ScrollingContainer
 
                 currentYpos += elementHeight + childSpacing;
             }
-        }
 
-        while (currentEmptyTextComponent == null && children.size() > numElements)
-        {
-            removeChild(children.get(numElements));
+            while (children.size() > numElements)
+            {
+                removeChild(children.get(numElements));
+            }
         }
-
-        if (numElements == 0 && currentEmptyTextComponent == null)
+        else
         {
-            currentEmptyTextComponent = new Text();
-            currentEmptyTextComponent.setSize(this.width, this.height);
-            currentEmptyTextComponent.setTextAlignment(Alignment.MIDDLE);
-            currentEmptyTextComponent.setText(emptyText);
-            currentEmptyTextComponent.setTextScale(emptyTextScale);
-            currentEmptyTextComponent.setColors(emptyTextColor);
-            currentEmptyTextComponent.putInside(this);
+            if (emptyTextComponent.getParent() == null)
+            {
+                children.clear();
+                addChild(emptyTextComponent);
+            }
         }
 
         setContentHeight(currentYpos - childSpacing);

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
@@ -107,7 +107,10 @@ public class ScrollingListContainer extends ScrollingContainer
             return;
         }
 
-        emptyTextComponent.setSize(this.width, this.height);
+        if (this.width != emptyTextComponent.getWidth() || this.height != emptyTextComponent.getHeight())
+        {
+            emptyTextComponent.setSize(this.width, this.height);
+        }
 
         final int numElements = (dataProvider != null) ? dataProvider.getElementCount() : 0;
         if (numElements > 0)

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
@@ -1,19 +1,42 @@
 package com.ldtteam.blockui.views;
 
+import com.ldtteam.blockui.Alignment;
 import com.ldtteam.blockui.Loader;
 import com.ldtteam.blockui.Pane;
 import com.ldtteam.blockui.PaneParams;
+import com.ldtteam.blockui.controls.Text;
 import com.ldtteam.blockui.util.SafeError;
 import com.ldtteam.blockui.util.records.SizeI;
 import com.ldtteam.blockui.views.ScrollingList.DataProvider;
+import net.minecraft.network.chat.MutableComponent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+import static com.ldtteam.blockui.controls.AbstractTextElement.DEFAULT_TEXT_COLOR;
+import static com.ldtteam.blockui.controls.AbstractTextElement.DEFAULT_TEXT_SCALE;
 
 /**
  * A Blockout pane that contains a scrolling line of other panes.
  */
 public class ScrollingListContainer extends ScrollingContainer
 {
+    /**
+     * The current empty text values.
+     */
+    private List<MutableComponent> emptyText;
+
+    /**
+     * The current empty text color for the {@link ScrollingListContainer#emptyText}.
+     */
+    private int emptyTextColor = DEFAULT_TEXT_COLOR;
+
+    /**
+     * The current empty text scale for the {@link ScrollingListContainer#emptyText}.
+     */
+    private double emptyTextScale = DEFAULT_TEXT_SCALE;
+
     /**
      * The xml parameters for the row panes.
      */
@@ -25,9 +48,56 @@ public class ScrollingListContainer extends ScrollingContainer
      */
     private SizeI templateSize = new SizeI(0, 0);
 
+    /**
+     * The reference to the empty text label, if it exists.
+     */
+    private Text currentEmptyTextComponent;
+
     ScrollingListContainer(final ScrollingList owner)
     {
         super(owner);
+    }
+
+    /**
+     * Set the text shown when there are no items in the data provider.
+     *
+     * @param emptyText the list of components.
+     */
+    public void setEmptyText(final List<MutableComponent> emptyText)
+    {
+        this.emptyText = emptyText;
+        if (currentEmptyTextComponent != null)
+        {
+            currentEmptyTextComponent.setText(emptyText);
+        }
+    }
+
+    /**
+     * Set the text color for the {@link ScrollingListContainer#emptyText}.
+     *
+     * @param emptyTextColor the color.
+     */
+    public void setEmptyTextColor(final int emptyTextColor)
+    {
+        this.emptyTextColor = emptyTextColor;
+        if (currentEmptyTextComponent != null)
+        {
+            currentEmptyTextComponent.setColors(emptyTextColor);
+        }
+    }
+
+    /**
+     * Set the text scale for the {@link ScrollingListContainer#emptyText}.
+     *
+     * @param emptyTextScale the text scale.
+     */
+    public void setEmptyTextScale(final double emptyTextScale)
+    {
+        this.emptyTextScale = emptyTextScale;
+        if (currentEmptyTextComponent != null)
+        {
+            currentEmptyTextComponent.setTextScale(emptyTextScale);
+        }
     }
 
     /**
@@ -65,6 +135,12 @@ public class ScrollingListContainer extends ScrollingContainer
         final int numElements = (dataProvider != null) ? dataProvider.getElementCount() : 0;
         if (numElements > 0)
         {
+            if (currentEmptyTextComponent != null)
+            {
+                removeChild(currentEmptyTextComponent);
+                currentEmptyTextComponent = null;
+            }
+
             final RowSizeModifier modifier = new RowSizeModifier();
 
             for (int i = 0; i < numElements; ++i)
@@ -102,9 +178,20 @@ public class ScrollingListContainer extends ScrollingContainer
             }
         }
 
-        while (children.size() > numElements)
+        while (currentEmptyTextComponent == null && children.size() > numElements)
         {
             removeChild(children.get(numElements));
+        }
+
+        if (numElements == 0 && currentEmptyTextComponent == null)
+        {
+            currentEmptyTextComponent = new Text();
+            currentEmptyTextComponent.setSize(this.width, this.height);
+            currentEmptyTextComponent.setTextAlignment(Alignment.MIDDLE);
+            currentEmptyTextComponent.setText(emptyText);
+            currentEmptyTextComponent.setTextScale(emptyTextScale);
+            currentEmptyTextComponent.setColors(emptyTextColor);
+            currentEmptyTextComponent.putInside(this);
         }
 
         setContentHeight(currentYpos - childSpacing);

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
@@ -115,7 +115,10 @@ public class ScrollingListContainer extends ScrollingContainer
         final int numElements = (dataProvider != null) ? dataProvider.getElementCount() : 0;
         if (numElements > 0)
         {
-            removeChild(emptyTextComponent);
+            if (emptyTextComponent.getParent() != null)
+            {
+                removeChild(emptyTextComponent);
+            }
 
             final RowSizeModifier modifier = new RowSizeModifier();
 

--- a/src/main/java/com/ldtteam/blockui/views/View.java
+++ b/src/main/java/com/ldtteam/blockui/views/View.java
@@ -368,6 +368,7 @@ public class View extends Pane
     public void removeChild(final Pane child)
     {
         children.remove(child);
+        child.setParentView(null);
     }
 
     @Override

--- a/src/main/resources/assets/blockui/gui/block_ui.xsd
+++ b/src/main/resources/assets/blockui/gui/block_ui.xsd
@@ -182,6 +182,10 @@
         <xs:complexContent>
             <xs:extension base="scrollViewType">
                 <xs:group ref="paneContainerGroup" minOccurs="1" maxOccurs="1"/>
+
+                <xs:attribute name="emptytext" type="xs:string"/>
+                <xs:attribute name="emptyscale" type="xs:string"/>
+                <xs:attribute name="emptycolor" type="xs:string"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/src/main/resources/assets/blockui/gui/test4.xml
+++ b/src/main/resources/assets/blockui/gui/test4.xml
@@ -1,4 +1,4 @@
-<window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="block_ui.xsd" size="480 240" type="FIXED_VANILLA" pause="true" lightbox="true">
+<window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="block_ui.xsd" size="640 240" type="FIXED_VANILLA" pause="true" lightbox="true">
     <list id="list1" size="160 240">
         <label size="152 20"/>
     </list>
@@ -16,4 +16,9 @@
                       checkmark="blockui:textures/gui/overlay_mini_check.png"/>
         </view>
     </list>
+    <list id="list4" size="160 200" pos="480 0" emptytext="This list is empty" emptyscale="0.8" emptycolor="white">
+        <label size="152 20"/>
+    </list>
+    <button id="list4add" pos="480 200" size="160 20" label="Add item"/>
+    <button id="list4remove" pos="480 220" size="160 20" label="Remove item"/>
 </window>


### PR DESCRIPTION
closes #84 

- Allows you to set an "empty text" on lists, which will show the given text in the middle of the list when no items are present.
- 3 new attributes for this: `emptytext`, `emptycolor` and `emptyscale`.
- New test written in test 4 for this usecase.

![2024-03-06 18_53_42-Minecraft Forge_ 1 20 1 - Singleplayer](https://github.com/ldtteam/BlockUI/assets/14359461/7d03f693-a96f-482b-b666-00218fce1728)
![2024-03-06 18_53_46-Minecraft Forge_ 1 20 1 - Singleplayer](https://github.com/ldtteam/BlockUI/assets/14359461/1de6a395-193d-4977-901d-05875d78a606)
