### PR TITLE
Allow skipping list updates

### DIFF
--- a/src/main/java/com/ldtteam/blockui/mod/ScrollingListsGui.java
+++ b/src/main/java/com/ldtteam/blockui/mod/ScrollingListsGui.java
@@ -13,6 +13,8 @@ import net.minecraft.network.chat.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -127,5 +129,32 @@ public class ScrollingListsGui
 
         window.findPaneOfTypeByID("list4add", Button.class).setHandler(button -> renderAmount.getAndAdd(2));
         window.findPaneOfTypeByID("list4remove", Button.class).setHandler(button -> renderAmount.getAndAdd(-2));
+
+        // Case 5: A list that will not update
+        final AtomicBoolean shouldRenderFlag = new AtomicBoolean();
+        final ScrollingList list5 = window.findPaneOfTypeByID("list5", ScrollingList.class);
+        list5.setDataProvider(new DataProvider()
+        {
+            @Override
+            public int getElementCount()
+            {
+                return 10;
+            }
+
+            @Override
+            public boolean shouldUpdate()
+            {
+                return shouldRenderFlag.get();
+            }
+
+            @Override
+            public void updateElement(final int index, final Pane rowPane)
+            {
+                shouldRenderFlag.set(false);
+                rowPane.findPaneByType(Text.class).setText(Component.literal("Hi " + index + " " + UUID.randomUUID()));
+            }
+        });
+
+        window.findPaneOfTypeByID("list5update", Button.class).setHandler(button -> shouldRenderFlag.set(true));
     }
 }

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingList.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingList.java
@@ -121,7 +121,7 @@ public class ScrollingList extends ScrollingView
     public void setDataProvider(final DataProvider p)
     {
         dataProvider = p;
-        refreshElementPanes();
+        refreshElementPanes(true);
     }
 
     /**
@@ -129,14 +129,24 @@ public class ScrollingList extends ScrollingView
      */
     public void refreshElementPanes()
     {
-        ((ScrollingListContainer) container).refreshElementPanes(dataProvider, maxHeight, childSpacing);
+        refreshElementPanes(true);
+    }
+
+    /**
+     * Use the data provider to update all the element panes.
+     *
+     * @param force should the list be forcefully updated.
+     */
+    public void refreshElementPanes(boolean force)
+    {
+        ((ScrollingListContainer) container).refreshElementPanes(dataProvider, maxHeight, childSpacing, force);
     }
 
     @Override
     public void onUpdate()
     {
         super.onUpdate();
-        refreshElementPanes();
+        refreshElementPanes(false);
     }
 
     @Override
@@ -184,6 +194,26 @@ public class ScrollingList extends ScrollingView
          * @return number of rows in the list
          */
         int getElementCount();
+
+        /**
+         * Should all the children update again?
+         *
+         * @return true if the updates should be made
+         */
+        default boolean shouldUpdate()
+        {
+            return true;
+        }
+
+        /**
+         * Should the specific child update again?
+         *
+         * @return true if the updates should be made
+         */
+        default boolean shouldUpdate(int index)
+        {
+            return true;
+        }
 
         /**
          * Override this to pick a custom size for this element. Event contains the logic to modify the old size.

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingList.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingList.java
@@ -137,7 +137,7 @@ public class ScrollingList extends ScrollingView
      *
      * @param force should the list be forcefully updated.
      */
-    public void refreshElementPanes(boolean force)
+    public void refreshElementPanes(final boolean force)
     {
         ((ScrollingListContainer) container).refreshElementPanes(dataProvider, maxHeight, childSpacing, force);
     }
@@ -210,7 +210,7 @@ public class ScrollingList extends ScrollingView
          *
          * @return true if the updates should be made
          */
-        default boolean shouldUpdate(int index)
+        default boolean shouldUpdate(final int index)
         {
             return true;
         }
@@ -221,7 +221,7 @@ public class ScrollingList extends ScrollingView
          * @param index    the index of the row/list element.
          * @param modifier the object used to modify the size.
          */
-        default void modifyRowSize(int index, final RowSizeModifier modifier)
+        default void modifyRowSize(final int index, final RowSizeModifier modifier)
         {
             // No implementation by default
         }

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
@@ -155,14 +155,14 @@ public class ScrollingListContainer extends ScrollingContainer
                         }
                     }
 
-                    child.setPosition(0, currentYpos);
-                    if (modifier.modified)
+                    if (force || dataProvider.shouldUpdate(i))
                     {
-                        child.setSize(modifier.width, modifier.height);
-                    }
+                        child.setPosition(0, currentYpos);
+                        if (modifier.modified)
+                        {
+                            child.setSize(modifier.width, modifier.height);
+                        }
 
-                    if (!force && dataProvider.shouldUpdate(i))
-                    {
                         dataProvider.updateElement(i, child);
                     }
                 }

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
@@ -96,9 +96,15 @@ public class ScrollingListContainer extends ScrollingContainer
      * @param dataProvider data provider object, shouldn't be null.
      * @param height       the maximum height of the parent.
      * @param childSpacing the spacing between each row.
+     * @param force        should the list be forcefully updated.
      */
-    public void refreshElementPanes(final DataProvider dataProvider, final int height, final int childSpacing)
+    public void refreshElementPanes(final DataProvider dataProvider, final int height, final int childSpacing, final boolean force)
     {
+        if (dataProvider == null)
+        {
+            return;
+        }
+
         int currentYpos = 0;
 
         if (listNodeParams == null)
@@ -107,12 +113,17 @@ public class ScrollingListContainer extends ScrollingContainer
             return;
         }
 
+        if (!force && !dataProvider.shouldUpdate())
+        {
+            return;
+        }
+
         if (this.width != emptyTextComponent.getWidth() || this.height != emptyTextComponent.getHeight())
         {
             emptyTextComponent.setSize(this.width, this.height);
         }
 
-        final int numElements = (dataProvider != null) ? dataProvider.getElementCount() : 0;
+        final int numElements = dataProvider.getElementCount();
         if (numElements > 0)
         {
             if (emptyTextComponent.getParent() != null)
@@ -150,7 +161,10 @@ public class ScrollingListContainer extends ScrollingContainer
                         child.setSize(modifier.width, modifier.height);
                     }
 
-                    dataProvider.updateElement(i, child);
+                    if (!force && dataProvider.shouldUpdate(i))
+                    {
+                        dataProvider.updateElement(i, child);
+                    }
                 }
 
                 currentYpos += elementHeight + childSpacing;

--- a/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
+++ b/src/main/java/com/ldtteam/blockui/views/ScrollingListContainer.java
@@ -155,14 +155,14 @@ public class ScrollingListContainer extends ScrollingContainer
                         }
                     }
 
+                    child.setPosition(0, currentYpos);
+                    if (modifier.modified)
+                    {
+                        child.setSize(modifier.width, modifier.height);
+                    }
+
                     if (force || dataProvider.shouldUpdate(i))
                     {
-                        child.setPosition(0, currentYpos);
-                        if (modifier.modified)
-                        {
-                            child.setSize(modifier.width, modifier.height);
-                        }
-
                         dataProvider.updateElement(i, child);
                     }
                 }

--- a/src/main/resources/assets/blockui/gui/test4.xml
+++ b/src/main/resources/assets/blockui/gui/test4.xml
@@ -1,4 +1,4 @@
-<window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="block_ui.xsd" size="640 240" type="FIXED_VANILLA" pause="true" lightbox="true">
+<window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="block_ui.xsd" size="640 480" type="FIXED_VANILLA" pause="true" lightbox="true">
     <list id="list1" size="160 240">
         <label size="152 20"/>
     </list>
@@ -21,4 +21,8 @@
     </list>
     <button id="list4add" pos="480 200" size="160 20" label="Add item"/>
     <button id="list4remove" pos="480 220" size="160 20" label="Remove item"/>
+    <list id="list5" size="160 200" pos="0 240" emptytext="This list is empty" emptyscale="0.8" emptycolor="white">
+        <label size="152 20"/>
+    </list>
+    <button id="list5update" pos="0 440" size="160 20" label="Update list"/>
 </window>


### PR DESCRIPTION
- 2 new methods in the data providers that allows blocking updates to:
  - The entire list
  - An individual item