### PR TITLE
Fix versioning for 1.20 with new OPC update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,6 +27,8 @@ additionalMinecraftVersions=
 mappingsChannel=official
 mappingsVersion=1.20.1
 
+usesMCVersionOrderFirst=true
+
 githubUrl=https://github.com/ldtteam/BlockUI
 gitUrl=https://github.com/ldtteam/BlockUI.git
 gitConnectUrl=https://github.com/ldtteam/BlockUI.git


### PR DESCRIPTION
See https://github.com/ldtteam/OperaPublicaCreator/pull/30