### PR TITLE
Windows should no longer pause by default

### DIFF
--- a/src/main/java/com/ldtteam/blockui/views/BOWindow.java
+++ b/src/main/java/com/ldtteam/blockui/views/BOWindow.java
@@ -39,12 +39,12 @@ public class BOWindow extends View
     /**
      * Defines if the window should pause the game.
      */
-    protected boolean windowPausesGame = true;
+    protected boolean windowPausesGame = false;
 
     /**
      * Defines if the window should have a lightbox.
      */
-    protected boolean lightbox = true;
+    protected boolean lightbox = false;
 
     /**
      * Render using size or attemp to scale to fullscreen.


### PR DESCRIPTION
To mirror vanilla GUI's (and in support of ldtteam/minecolonies#10675) the pause behaviour should be off by default, as nearly none of the vanilla GUI's actually pause the screen, besides the escape menu.