### PR TITLE
Fix dropdown focus retention requiring double ESC

### DIFF
--- a/src/main/java/com/ldtteam/blockui/views/DropDownList.java
+++ b/src/main/java/com/ldtteam/blockui/views/DropDownList.java
@@ -135,6 +135,7 @@ public class DropDownList extends View implements ButtonHandler
     public void close()
     {
         overlay.setVisible(false);
+        Pane.clearFocus();
     }
 
     /**
@@ -286,7 +287,7 @@ public class DropDownList extends View implements ButtonHandler
         button.setEnabled(e);
         list.setEnabled(e);
     }
-    
+
     @Override
     public void parseChildren(PaneParams params)
     {


### PR DESCRIPTION
# Changes proposed in this pull request
- Fix dropdown retaining focus after selection, requiring double ESC to close windows
- Add `Pane.clearFocus()` call when closing dropdowns to properly release focus

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please