### PR TITLE
Return uncached sections in getSections() method

### DIFF
--- a/src/main/java/com/ldtteam/common/fakelevel/FakeChunk.java
+++ b/src/main/java/com/ldtteam/common/fakelevel/FakeChunk.java
@@ -223,7 +223,12 @@ public class FakeChunk extends LevelChunk
     public LevelChunkSection[] getSections()
     {
         // don't cache them
-        return new LevelChunkSection[0];
+        final FakeLevelChunkSection[] sections = new FakeLevelChunkSection[fakeLevel.getSectionsCount()];
+        for (int i = 0; i < sections.length; i++)
+        {
+            sections[i] = new FakeLevelChunkSection(this, i); 
+        }
+        return sections;
     }
 
     @Override


### PR DESCRIPTION
Closes on our end https://github.com/ldtteam/Structurize/issues/799

# Changes proposed in this pull request
- return one-time use array, vanilla rendering doesn't even use this method
- not tested as no time :)  

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please
