### PR TITLE
Accessibility Feature

### DIFF
--- a/src/main/java/com/ldtteam/blockui/BOGuiGraphics.java
+++ b/src/main/java/com/ldtteam/blockui/BOGuiGraphics.java
@@ -1,5 +1,6 @@
 package com.ldtteam.blockui;
 
+import com.ldtteam.blockui.mod.BlockUI;
 import com.ldtteam.blockui.mod.item.BlockStateRenderingData;
 import com.ldtteam.blockui.util.SingleBlockGetter.SingleBlockNeighborhood;
 import com.ldtteam.blockui.util.cursor.Cursor;
@@ -55,12 +56,68 @@ public class BOGuiGraphics extends GuiGraphics
 
     public void renderItemDecorations(final ItemStack itemStack, final int x, final int y)
     {
-        super.renderItemDecorations(getFont(itemStack), itemStack, x, y);
+        renderItemDecorations(itemStack, x, y, null, false);
     }
 
     public void renderItemDecorations(final ItemStack itemStack, final int x, final int y, @Nullable final String altStackSize)
     {
-        super.renderItemDecorations(getFont(itemStack), itemStack, x, y, altStackSize);
+        renderItemDecorations(itemStack, x, y, altStackSize, false);
+    }
+
+    public void renderItemDecorations(final ItemStack itemStack, final int x, final int y, final boolean forceHighContrastCount)
+    {
+        renderItemDecorations(itemStack, x, y, null, forceHighContrastCount);
+    }
+
+    /**
+     * Renders vanilla item decorations, optionally drawing a high-contrast badge behind the stack count.
+     *
+     * @param itemStack item stack whose decorations will be rendered
+     * @param x item icon x position
+     * @param y item icon y position
+     * @param altStackSize optional text to render instead of the stack count
+     * @param forceHighContrastCount true to draw the count badge even when the client option is disabled
+     */
+    public void renderItemDecorations(
+        final ItemStack itemStack,
+        final int x,
+        final int y,
+        @Nullable final String altStackSize,
+        final boolean forceHighContrastCount)
+    {
+        final Font font = getFont(itemStack);
+        if (BlockUI.isHighContrastCountEnabled() || forceHighContrastCount)
+        {
+            drawCountBadge(font, itemStack, x, y, altStackSize);
+        }
+
+        super.renderItemDecorations(font, itemStack, x, y, altStackSize);
+    }
+
+    /**
+     * Draws a high-contrast 'badge' under the item decoration.
+     * @param font font used to measure count text
+     * @param itemStack item stack being highlighted
+     * @param x left
+     * @param y top
+     * @param altStackSize optional text to render instead of the stack count
+     */
+    private void drawCountBadge(final Font font, final ItemStack itemStack, final int x, final int y, @Nullable final String altStackSize)
+    {
+        final String countText = altStackSize == null ? itemStack.getCount() == 1 ? null : String.valueOf(itemStack.getCount()) : altStackSize;
+        if (countText == null || countText.isEmpty())
+        {
+            return;
+        }
+
+        final int textWidth = font.width(countText);
+        final int textX = x + 17 - textWidth;
+        final int textY = y + 9;
+
+        pose().pushPose();
+        pose().translate(0, 0, 199);
+        UiRenderMacros.fillRoundedBadge(pose(), textX - 2, textY - 1, textWidth + 4, font.lineHeight + 1, 0x99000000);
+        pose().popPose();
     }
 
     public int drawString(final String text, final float x, final float y, final int color)

--- a/src/main/java/com/ldtteam/blockui/UiRenderMacros.java
+++ b/src/main/java/com/ldtteam/blockui/UiRenderMacros.java
@@ -198,6 +198,26 @@ public class UiRenderMacros
         fill(ps, x, y, w, h, (argbColor >> 16) & 0xff, (argbColor >> 8) & 0xff, argbColor & 0xff, (argbColor >> 24) & 0xff);
     }
 
+    /**
+     * Draws a rounded 'badge' at the specified location.
+     * @param ps pose stack
+     * @param x item icon x position
+     * @param y item icon y position
+     * @param w width
+     * @param h height
+     * @param argbColor ARGB color
+     */
+    public static void fillRoundedBadge(final PoseStack ps, final int x, final int y, final int w, final int h, final int argbColor)
+    {
+        if (w < 3 || h < 3)
+        {
+            return;
+        }
+
+        fill(ps, x + 1, y, w - 2, h, argbColor);
+        fill(ps, x, y + 1, w, h - 2, argbColor);
+    }
+
     public static void fill(final PoseStack ps,
         final int x,
         final int y,

--- a/src/main/java/com/ldtteam/blockui/controls/ItemIcon.java
+++ b/src/main/java/com/ldtteam/blockui/controls/ItemIcon.java
@@ -48,6 +48,7 @@ public class ItemIcon extends Pane
      */
     protected boolean tooltipUpdateScheduled = false;
     protected boolean renderItemDecorations = true;
+    protected boolean forceHighContrastCount = false;
 
     /**
      * Standard constructor instantiating the itemIcon without any additional settings.
@@ -77,6 +78,7 @@ public class ItemIcon extends Pane
         }
 
         this.renderItemDecorations = params.getBoolean("renderItemDecorations", renderItemDecorations);
+        this.forceHighContrastCount = params.getBoolean("forceHighContrastCount", forceHighContrastCount);
     }
 
     /**
@@ -123,6 +125,22 @@ public class ItemIcon extends Pane
     public boolean renderItemDecorations()
     {
         return renderItemDecorations;
+    }
+
+    /**
+     * @param forceHighContrastCount true if count decorations should render with a high contrast badge for this icon.
+     */
+    public void setForceHighContrastCount(final boolean forceHighContrastCount)
+    {
+        this.forceHighContrastCount = forceHighContrastCount;
+    }
+
+    /**
+     * @return true if this icon forces high contrast count rendering.
+     */
+    public boolean forceHighContrastCount()
+    {
+        return forceHighContrastCount;
     }
 
     /**
@@ -194,7 +212,7 @@ public class ItemIcon extends Pane
             target.renderItem(itemStack, 0, 0);
             if (renderItemDecorations)
             {
-                target.renderItemDecorations(itemStack, 0, 0);
+                target.renderItemDecorations(itemStack, 0, 0, forceHighContrastCount);
             }
 
             RenderSystem.defaultBlendFunc();

--- a/src/main/java/com/ldtteam/blockui/controls/ItemIconWithBlockState.java
+++ b/src/main/java/com/ldtteam/blockui/controls/ItemIconWithBlockState.java
@@ -147,7 +147,7 @@ public class ItemIconWithBlockState extends ItemIcon
         target.renderBlockStateAsItem(blockStateExtension, itemStack);
         if (renderItemDecorations)
         {
-            target.renderItemDecorations(itemStack, 0, 0);
+            target.renderItemDecorations(itemStack, 0, 0, forceHighContrastCount);
         }
 
         RenderSystem.defaultBlendFunc();

--- a/src/main/java/com/ldtteam/blockui/mod/BlockUI.java
+++ b/src/main/java/com/ldtteam/blockui/mod/BlockUI.java
@@ -1,5 +1,8 @@
 package com.ldtteam.blockui.mod;
 
+import com.ldtteam.blockui.mod.config.BlockUIClientConfiguration;
+import com.ldtteam.common.config.AbstractConfiguration;
+import com.ldtteam.common.config.Configurations;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
@@ -10,16 +13,29 @@ import net.neoforged.neoforge.common.NeoForge;
 public class BlockUI
 {
     public static final String MOD_ID = "blockui";
+    public static Configurations<BlockUIClientConfiguration, AbstractConfiguration, AbstractConfiguration> configuration;
 
     public BlockUI(final FMLModContainer modContainer, final Dist dist)
     {
         final IEventBus modBus = modContainer.getEventBus();
         final IEventBus forgeBus = NeoForge.EVENT_BUS;
 
+        configuration = new Configurations<>(
+            modContainer,
+            modBus,
+            BlockUIClientConfiguration::new,
+            null,
+            null);
+
         if (dist.isClient())
         {
             modBus.register(ClientLifecycleSubscriber.class);
             forgeBus.register(ClientEventSubscriber.class);
         }
+    }
+
+    public static boolean isHighContrastCountEnabled()
+    {
+        return configuration != null && configuration.getClient() != null && configuration.getClient().highContrastCount.get();
     }
 }

--- a/src/main/java/com/ldtteam/blockui/mod/config/BlockUIClientConfiguration.java
+++ b/src/main/java/com/ldtteam/blockui/mod/config/BlockUIClientConfiguration.java
@@ -1,0 +1,23 @@
+package com.ldtteam.blockui.mod.config;
+
+import com.ldtteam.blockui.mod.BlockUI;
+import com.ldtteam.common.config.AbstractConfiguration;
+import net.neoforged.neoforge.common.ModConfigSpec.BooleanValue;
+import net.neoforged.neoforge.common.ModConfigSpec.Builder;
+
+/**
+ * Client-side BlockUI configuration.
+ */
+public class BlockUIClientConfiguration extends AbstractConfiguration
+{
+    public final BooleanValue highContrastCount;
+
+    public BlockUIClientConfiguration(final Builder builder)
+    {
+        super(builder, BlockUI.MOD_ID);
+
+        createCategory("visuals");
+        highContrastCount = defineBoolean("highContrastCount", false);
+        finishCategory();
+    }
+}

--- a/src/main/resources/assets/blockui/gui/block_ui.xsd
+++ b/src/main/resources/assets/blockui/gui/block_ui.xsd
@@ -216,6 +216,7 @@
                 <xs:attribute name="nbt" type="xs:string"/>
                 <xs:attribute name="properties" type="xs:string"/>
                 <xs:attribute name="renderItemDecorations" type="xs:boolean" default="true"/>
+                <xs:attribute name="forceHighContrastCount" type="xs:boolean" default="false"/>
                 <xs:attribute name="alwaysAddBlockStateTooltip" type="xs:boolean" default="false"/>
             </xs:extension>
         </xs:complexContent>

--- a/src/main/resources/assets/blockui/lang/en_us.json
+++ b/src/main/resources/assets/blockui/lang/en_us.json
@@ -6,5 +6,9 @@
     "blockui.config.default.boolean": "[Default: %s]",
     "blockui.config.default.string": "[Default: %s]",
     "blockui.config.default.enum": "[Default: %s, values: %s]",
-    "blockui.config.default.number": "[Default: %s, min: %s, max: %s]"
+    "blockui.config.default.number": "[Default: %s, min: %s, max: %s]",
+    "blockui.config.visuals": "Visuals",
+    "blockui.config.visuals.comment": "Client-side visual options.",
+    "blockui.config.highContrastCount": "High Contrast Count",
+    "blockui.config.highContrastCount.comment": "Draws a dark translucent badge behind item stack counts."
 }


### PR DESCRIPTION
Closes [Discord Suggestion](https://discord.com/channels/472875599422291968/1521565015558328492)

# Changes proposed in this pull request
- Introduce a client-side setting allowing a player to display a 'badge' under the item stack count for greater visibility: "highContrastCount" (defaults to false)
- Allow this same feature to be indicated through the layout with a new attribute.

## AI
I did use AI on this feature - both to understand the current functionality, and to implement (and then review) the changes. I did review every line of changes to ensure I had a solid understanding of the purpose.

## Example
<img width="1121" height="1411" alt="image" src="https://github.com/user-attachments/assets/f8800410-083f-4114-8bc9-e826ee248c81" />

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please
