### PR TITLE
Fix ConcurrentModificationException in View draw loops

### DIFF
--- a/src/main/java/com/ldtteam/blockui/views/View.java
+++ b/src/main/java/com/ldtteam/blockui/views/View.java
@@ -83,7 +83,7 @@ public class View extends Pane
         final double drawX = mx - paddedX;
         final double drawY = my - paddedY;
 
-        for (final Pane child : children)
+        for (final Pane child : new ArrayList<>(children))
         {
             if (childIsVisible(child))
             {
@@ -101,7 +101,7 @@ public class View extends Pane
     @Override
     public void drawHidden()
     {
-        for (final Pane child : children)
+        for (final Pane child : new ArrayList<>(children))
         {
             child.drawHidden();
         }
@@ -124,7 +124,7 @@ public class View extends Pane
         final double drawX = mx - paddedX;
         final double drawY = my - paddedY;
 
-        for (final Pane child : children)
+        for (final Pane child : new ArrayList<>(children))
         {
             if (childIsVisible(child))
             {


### PR DESCRIPTION
Closes #129

# Changes proposed in this pull request
- `View#drawSelf`, `#drawHidden` and `#drawSelfLast` iterated the live `children` list, so a structural change to it during a render pass crashed the client with `ConcurrentModificationException`. Stack and analysis are in #129.
- Applied the same defensive copy that `View#onUpdate` already uses (`new ArrayList<>(children)`) to those three draw paths. Scope is kept to the per-frame draw methods; `findPaneByID`, `findPaneByType`, `setWindow` and the reverse `listIterator` in `mouseEventProcessor` are left as-is. Happy to widen it if you would prefer the whole class handled at once.

## Testing
- [x] Yes I tested this before submitting it.
- [x] I also did a multiplayer test.
